### PR TITLE
IAM User Group Membership for AWS IAM Terraform Modules

### DIFF
--- a/modules/iam-group-with-assumable-roles-policy/main.tf
+++ b/modules/iam-group-with-assumable-roles-policy/main.tf
@@ -21,11 +21,9 @@ resource "aws_iam_group_policy_attachment" "this" {
   policy_arn = aws_iam_policy.this.id
 }
 
-resource "aws_iam_group_membership" "this" {
-  count = length(var.group_users) > 0 ? 1 : 0
+resource "aws_iam_user_group_membership" "this" {
+  count = length(var.group_users)
 
-  group = aws_iam_group.this.id
-  name  = var.name
-  users = var.group_users
+  user = element(var.group_users, count.index)
+  groups = [local.group_name]
 }
-

--- a/modules/iam-group-with-assumable-roles-policy/outputs.tf
+++ b/modules/iam-group-with-assumable-roles-policy/outputs.tf
@@ -1,6 +1,6 @@
 output "this_group_users" {
   description = "List of IAM users in IAM group"
-  value       = flatten(aws_iam_group_membership.this.*.users)
+  value       = distinct(flatten(aws_iam_user_group_membership.this[*].user))
 }
 
 output "this_assumable_roles" {

--- a/modules/iam-group-with-policies/main.tf
+++ b/modules/iam-group-with-policies/main.tf
@@ -8,12 +8,11 @@ resource "aws_iam_group" "this" {
   name = var.name
 }
 
-resource "aws_iam_group_membership" "this" {
-  count = length(var.group_users) > 0 ? 1 : 0
+resource "aws_iam_user_group_membership" "this" {
+  count = length(var.group_users)
 
-  group = local.group_name
-  name  = var.name
-  users = var.group_users
+  user = element(var.group_users, count.index)
+  groups = [local.group_name]
 }
 
 ################################

--- a/modules/iam-group-with-policies/outputs.tf
+++ b/modules/iam-group-with-policies/outputs.tf
@@ -5,7 +5,7 @@ output "aws_account_id" {
 
 output "this_group_users" {
   description = "List of IAM users in IAM group"
-  value       = flatten(aws_iam_group_membership.this.*.users)
+  value       = distinct(flatten(aws_iam_user_group_membership.this[*].user))
 }
 
 output "this_group_name" {


### PR DESCRIPTION
* User aws_iam_user_group_membership resource so that each user_group_membership can be individually managed/imported

* Use aws_iam_user_group_membership resource for iam-group-with-assumable-roles-policy so that each user_group_membership can be individually managed/imported

* Switch to using `count` instead of `for_each`

(cherry picked from commit https://github.com/pcockwell/terraform-aws-iam/commit/c1ce62a0add9bfc4933713b1b07f5ca35c291c9a)